### PR TITLE
Changed the type stored in Numerus from int to uint8_t

### DIFF
--- a/include/BigInt.hpp
+++ b/include/BigInt.hpp
@@ -12,7 +12,7 @@
 
         private:
 
-         std::vector<int> numerus;
+         std::vector<uint8_t> numerus;
 
          SIGN sign;
 


### PR DESCRIPTION
The size of uint8_t is 1 byte, versus 4 bytes for an int, so this will save a lot of storage space.